### PR TITLE
ridurre descrizione a riga di comando

### DIFF
--- a/content/it/ricette/riga_comando/_index.md
+++ b/content/it/ricette/riga_comando/_index.md
@@ -3,7 +3,7 @@ title: "A riga di comando"
 linkTitle: "A riga di comando"
 weight: 1
 description: >
-  In informatica una interfaccia a riga di comando[1] (dall'inglese Command Line Interface, acronimo CLI) o anche console, a volte detta semplicemente riga di comando e, impropriamente, prompt dei comandi, è un tipo di interfaccia utente caratterizzata da un'interazione testuale tra utente ed elaboratore (vedi shell). L'utente impartisce comandi testuali in input mediante tastiera alfanumerica e riceve risposte testuali in output dall'elaboratore mediante display o stampante alfanumerici. [Fonte](https://it.wikipedia.org/wiki/Interfaccia_a_riga_di_comando)
+  In informatica un'interfaccia a riga di comando è un tipo di interfaccia utente caratterizzata da un'interazione testuale tra utente ed elaboratore. Spesso si indica anche con l'acronimo inglese CLI che sta per Command Line Interface [Leggi di più...](https://it.wikipedia.org/wiki/Interfaccia_a_riga_di_comando)
 ---
 
 Elenco Ricette


### PR DESCRIPTION
IMHO le descrizioni delle categorie di ricette sono eccessivamente lunghe. Qui la riduco un po'