### PR TITLE
modificata descrizione per categoria hugo

### DIFF
--- a/content/it/ricette/HugoServer/_index.md
+++ b/content/it/ricette/HugoServer/_index.md
@@ -3,7 +3,7 @@ title: "Hugo"
 linkTitle: "Hugo"
 weight: 8
 description: >
-         Server web ad alte prestazioni. Hugo fornisce un proprio server web che costruisce e serve il sito. Mentre il server hugo offre prestazioni elevate, è un server Web con opzioni limitate. Molti lo eseguono in produzione, ma il comportamento standard è che le persone lo utilizzino nello sviluppo e utilizzino un server più completo come Nginx o Caddy. [Fonte](https://gohugo.io/commands/hugo_server/)
+         Hugo è un generatore di siti statici scritto in Go. [Leggi di più](https://gohugo.io/about/what-is-hugo/)
 ---
 
 Elenco Ricette


### PR DESCRIPTION
In questa PR modifico la descrizione della categoria Hugo: prima era concentrata su Hugo server, adesso su Hugo come static site generator